### PR TITLE
Set up CI workflow for Java with Maven using JDK 19

### DIFF
--- a/.github/workflows/javatests.yml
+++ b/.github/workflows/javatests.yml
@@ -1,0 +1,27 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '19'
+
+
+      - name: Run tests with Maven
+        run: mvn clean test


### PR DESCRIPTION
- Trigger workflow on push and pull request to the main branch.
- Use Ubuntu-latest as the runner.
- Set up JDK 19 using temurin distribution.
- Run tests with Maven.